### PR TITLE
Grid fixes + saving the window position

### DIFF
--- a/src/com/modsim/gui/GUI.java
+++ b/src/com/modsim/gui/GUI.java
@@ -75,13 +75,28 @@ public class GUI {
 			Preferences prefs = Preferences.userNodeForPackage(GUI.class);
 			if (prefs.getBoolean("window_stored", false)) {
 				// Window border has been stored
-				int window_x, window_y, window_width, window_height;
-				window_x = prefs.getInt("window_x", 0);
-				window_y = prefs.getInt("window_y", 0);
-				window_height = prefs.getInt("window_height", 600);
-				window_width = prefs.getInt("window_width", 800);
-				frame.setBounds(window_x, window_y, window_width, window_height);
-				// Restore maximise state
+				int windowX, windowY, windowWidth, windowHeight;
+				windowX = prefs.getInt("window_x", 0);
+				windowY = prefs.getInt("window_y", 0);
+				windowHeight = prefs.getInt("window_height", 600);
+				windowWidth = prefs.getInt("window_width", 800);
+				// Check the window is within the boundaries of the active display(s)
+                GraphicsDevice[] devices = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices();
+                boolean onDesktop = false;
+                for (int i = 0; i < devices.length; i++) {
+                    Rectangle displayBounds = devices[i].getDefaultConfiguration().getBounds();
+                    if (displayBounds.intersects(windowX, windowY, windowWidth, windowHeight)) {
+                        onDesktop = true;
+                    }
+                }
+                if (onDesktop) {
+                    frame.setBounds(windowX, windowY, windowWidth, windowHeight);
+                }
+                else {
+                    frame.pack();
+                    frame.setLocationRelativeTo(null);
+                }
+				// Restores the maximise state
 				if (prefs.getBoolean("window_maximised", false)) {
 					frame.setExtendedState(frame.getExtendedState() | JFrame.MAXIMIZED_BOTH);
 				}

--- a/src/com/modsim/gui/view/View.java
+++ b/src/com/modsim/gui/view/View.java
@@ -1,7 +1,7 @@
 package com.modsim.gui.view;
 
 import java.awt.*;
-import java.awt.geom.AffineTransform;
+import java.awt.geom.*;
 import java.text.DecimalFormat;
 
 import javax.swing.*;
@@ -78,8 +78,8 @@ public class View extends JPanel {
         g.setColor(Colors.grid);
         double xD = (camX + getWidth()/2);
         double yD = (camY + getHeight()/2);
-        double xOff = (int)xD % (int)(Main.sim.grid * zoom);
-        double yOff = (int)yD % (int)(Main.sim.grid * zoom);
+        double xOff = xD % (Main.sim.grid * zoom);
+        double yOff = yD % (Main.sim.grid * zoom);
         g.translate(xOff, yOff);
         drawGrid(g);
 
@@ -168,13 +168,19 @@ public class View extends JPanel {
         int xNum = (int)(getWidth() / grid);
         int yNum = (int)(getHeight() / grid);
 
+        AffineTransform oldxform = new AffineTransform(g.getTransform());
+        Line2D verticalLine = new Line2D.Double(0.0, -grid, 0.0, getHeight() + grid);
+        Line2D horizontalLine = new Line2D.Double(-grid, 0.0, getWidth() + grid, 0.0);
         for (int i = 0; i <= xNum + 1; i++) {
-            g.drawLine((int)(i * grid), (int)-grid, (int)(i*grid), getHeight() + (int)grid);
+            g.draw(verticalLine);
+            g.translate(grid, 0.0);
         }
-
+        g.setTransform(oldxform);
         for (int i = 0; i <= yNum + 1; i++) {
-            g.drawLine((int)-grid, (int)(i * grid), getWidth() + (int)grid, (int)(i*grid));
+            g.draw(horizontalLine);
+            g.translate(0.0, grid);
         }
+        g.setTransform(oldxform);
     }
 
     /**


### PR DESCRIPTION
This corrects the background grid display at all zoom levels, which was getting misaligned due to integer rounding errors. I also added code to store and restore the main window's position, size and maximised state when closing/opening ModuleSim. Settings are held in user preferences, which is implementation-dependent (on windows it's the user registry)
