### PR TITLE
Bug fixes and consistent support for deletion keys

### DIFF
--- a/src/com/modsim/gui/view/ViewUtil.java
+++ b/src/com/modsim/gui/view/ViewUtil.java
@@ -410,7 +410,9 @@ public class ViewUtil implements MouseListener, MouseMotionListener, MouseWheelL
             }
         }
         // Delete selection
-        else if (e.getKeyCode() == KeyEvent.VK_DELETE
+        else if ((   e.getKeyCode() == KeyEvent.VK_DELETE
+                  || e.getKeyCode() == KeyEvent.VK_BACK_SPACE
+                  || e.getKeyCode() == KeyEvent.VK_X)
                  && !Main.selection.isEmpty()) {
             Main.selection.deleteAll();
         }

--- a/src/com/modsim/gui/view/ViewUtil.java
+++ b/src/com/modsim/gui/view/ViewUtil.java
@@ -277,6 +277,8 @@ public class ViewUtil implements MouseListener, MouseMotionListener, MouseWheelL
                 else {
                     Port p = screenSpace_portAt(e.getX(), e.getY());
 
+                    Main.selection.clear();
+
                     //Link behaviour
                     if (p != null) {
                         tool = new MakeLinkTool();
@@ -408,7 +410,8 @@ public class ViewUtil implements MouseListener, MouseMotionListener, MouseWheelL
             }
         }
         // Delete selection
-        else if (e.getKeyCode() == KeyEvent.VK_DELETE) {
+        else if (e.getKeyCode() == KeyEvent.VK_DELETE
+                 && !Main.selection.isEmpty()) {
             Main.selection.deleteAll();
         }
         // Pass to tool

--- a/src/com/modsim/gui/view/ViewUtil.java
+++ b/src/com/modsim/gui/view/ViewUtil.java
@@ -401,14 +401,14 @@ public class ViewUtil implements MouseListener, MouseMotionListener, MouseWheelL
         View v = Main.ui.view;
 
         // Cancel tool usage on escape press
-        if (e.getKeyChar() == KeyEvent.VK_ESCAPE) {
+        if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
             if (v.curTool != null) {
                 v.curTool.cancel();
                 v.curTool = null;
             }
         }
         // Delete selection
-        else if (e.getKeyChar() == KeyEvent.VK_DELETE) {
+        else if (e.getKeyCode() == KeyEvent.VK_DELETE) {
             Main.selection.deleteAll();
         }
         // Pass to tool

--- a/src/com/modsim/tools/EditLinkTool.java
+++ b/src/com/modsim/tools/EditLinkTool.java
@@ -136,6 +136,8 @@ public class EditLinkTool extends BaseTool {
     public BaseTool keyDown(int key) {
         switch (key) {
             case KeyEvent.VK_X:
+            case KeyEvent.VK_DELETE:
+            case KeyEvent.VK_BACK_SPACE:
                 Main.opStack.cancelCompoundOp();
                 link.highlight = false;
                 link.delete();

--- a/src/com/modsim/tools/MakeLinkTool.java
+++ b/src/com/modsim/tools/MakeLinkTool.java
@@ -94,7 +94,9 @@ public class MakeLinkTool extends BaseTool {
 	public boolean startLink(int x, int y) {
 		source = ViewUtil.screenSpace_portAt(x, y);
 		if (source != null) {
-			working = true;
+            Main.selection.clear();
+
+            working = true;
 			start = new Vec2(x, y);
 			curve = new BezierPath();
 

--- a/src/com/modsim/tools/MakeLinkTool.java
+++ b/src/com/modsim/tools/MakeLinkTool.java
@@ -68,7 +68,9 @@ public class MakeLinkTool extends BaseTool {
 
 	@Override
 	public BaseTool keyDown(int key) {
-		if (key == KeyEvent.VK_BACK_SPACE) {
+		if (   key == KeyEvent.VK_BACK_SPACE
+            || key == KeyEvent.VK_DELETE
+            || key == KeyEvent.VK_X) {
 			if (curve.removePt()) 	return this;
 			else 					return null;
 		}


### PR DESCRIPTION
These changes fix four issues:

1. Inconsistent use of X/Delete/Backspace keys for delete operations
2. Inconsistent state of selection of links/modules when CRUD'ing links
3. Inconsistent routing of key events to operations/handlers
4. Incorrect use of KeyChar for KeyCode comparisons (leading to incorrectly handled key events)

In my opinion, these changes have a small but noticeable effect on the usability of ModuleSim.