### PR TITLE
Add Linux build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+mkdir ./out
+find -name "*.java" > sources.txt
+javac -d ./out @sources.txt
+cd ./out
+find ../src -name "*.png" -exec cp '{}' ./com/modsim/res/ \;
+jar cfm ../ModuleSim-Test.jar ../src/META-INF/MANIFEST.MF ./
+cd ../
+rm ./sources.txt


### PR DESCRIPTION
This works for a "quick and dirty" release build on the lab machines at University of Bristol.

Use chmod +x build.sh to enable execution.
Execute from the root directory of the repo. 
Output is ModuleSim-Test.jar
If it works, rename to ModuleSim.jar and release.