### PR TITLE
Straight Paths

### DIFF
--- a/src/com/modsim/gui/view/ViewUtil.java
+++ b/src/com/modsim/gui/view/ViewUtil.java
@@ -12,7 +12,7 @@ import com.modsim.modules.ports.Output;
 import com.modsim.modules.parts.Port;
 import com.modsim.simulator.*;
 import com.modsim.tools.*;
-import com.modsim.util.BezierPath;
+import com.modsim.util.Path;
 import com.modsim.util.Vec2;
 
 /**
@@ -34,7 +34,7 @@ public class ViewUtil implements MouseListener, MouseMotionListener, MouseWheelL
      */
     public static Link worldSpace_linkAt(Vec2 pt) {
         for (Link link : Main.sim.getLinks()) {
-            BezierPath.PointInfo info = link.path.approxClosestPoint(pt, 6);
+            Path.PointInfo info = link.path.approxClosestPoint(pt, 6);
 
             if (info.dist < 15.0) {
                 return link;
@@ -267,12 +267,12 @@ public class ViewUtil implements MouseListener, MouseMotionListener, MouseWheelL
             boolean handled = false;
             if (targ != null && targ.getType() == PickableEntity.MODULE) {
                 BaseModule m = (BaseModule) targ;
-                handled = m.lbDown(e.getX(), e.getY());
+                handled = m.lbDown(e.getX(), e.getY(), e.isShiftDown());
             }
 
             if (!handled) {
                 if (tool != null) {
-                    Main.ui.view.curTool = tool.lbDown(e.getX(), e.getY());
+                    Main.ui.view.curTool = tool.lbDown(e.getX(), e.getY(), e.isShiftDown());
                 }
                 else {
                     Port p = screenSpace_portAt(e.getX(), e.getY());
@@ -282,7 +282,7 @@ public class ViewUtil implements MouseListener, MouseMotionListener, MouseWheelL
                     //Link behaviour
                     if (p != null) {
                         tool = new MakeLinkTool();
-                        Main.ui.view.curTool = tool.lbDown(e.getX(), e.getY());
+                        Main.ui.view.curTool = tool.lbDown(e.getX(), e.getY(), e.isShiftDown());
                     }
                     else {
                         // Link edit if we haven't hit a module
@@ -299,7 +299,7 @@ public class ViewUtil implements MouseListener, MouseMotionListener, MouseWheelL
 
                         // Finally, try selection behaviour
                         tool = new SelectTool();
-                        Main.ui.view.curTool = tool.lbDown(e.getX(), e.getY());
+                        Main.ui.view.curTool = tool.lbDown(e.getX(), e.getY(), e.isShiftDown());
                     }
                 }
             }

--- a/src/com/modsim/modules/BaseModule.java
+++ b/src/com/modsim/modules/BaseModule.java
@@ -560,7 +560,7 @@ public abstract class BaseModule extends PickableEntity {
      * @param iy Y coord in view space
      * @return Whether the input was handled
      */
-    public boolean lbDown(int ix, int iy) {
+    public boolean lbDown(int ix, int iy, boolean isShiftDown) {
         if (!enabled) return false;
 
         // Coords in object space
@@ -573,7 +573,7 @@ public abstract class BaseModule extends PickableEntity {
 
         synchronized (parts) {
             for (VisiblePart p : parts) {
-                if (p.lbDown(dx, dy)) {
+                if (p.lbDown(dx, dy, isShiftDown)) {
                     return true;
                 }
             }

--- a/src/com/modsim/modules/Link.java
+++ b/src/com/modsim/modules/Link.java
@@ -10,7 +10,9 @@ import com.modsim.modules.parts.Port;
 import com.modsim.Main;
 import com.modsim.res.Colors;
 import com.modsim.operations.DeleteOperation;
+import com.modsim.util.Path;
 import com.modsim.util.BezierPath;
+import com.modsim.util.StraightPath;
 import com.modsim.util.BinData;
 
 /**
@@ -22,7 +24,7 @@ public class Link {
 
     public Port src;
     public Port targ;
-    public BezierPath path;
+    public Path path;
 
     public boolean highlight = false;
 
@@ -47,7 +49,7 @@ public class Link {
      * @param path A bezier path to display for the link
      * @return New link, or null if link was invalid
      */
-    public static Link createLink(Port source, Port target, BezierPath path) {
+    public static Link createLink(Port source, Port target, Path path) {
         // Check error conditions first
 
     	if (source == null || target == null) {

--- a/src/com/modsim/modules/parts/PushBtn.java
+++ b/src/com/modsim/modules/parts/PushBtn.java
@@ -42,7 +42,7 @@ public class PushBtn extends TogglePart {
 	}
 
 	@Override
-	public boolean lbDown(int xPt, int yPt) {
+	public boolean lbDown(int xPt, int yPt, boolean isShiftDown) {
 		if (xPt > x-w/2 && xPt < x+w/2 && yPt > y-h/2 && yPt < y+h/2) {
 			// Clicked
 			setEnabled(true);

--- a/src/com/modsim/modules/parts/Switch.java
+++ b/src/com/modsim/modules/parts/Switch.java
@@ -36,7 +36,7 @@ public class Switch extends TogglePart {
     }
 
 	@Override
-	public boolean lbDown(int xPt, int yPt) {
+	public boolean lbDown(int xPt, int yPt, boolean isShiftDown) {
 		if (xPt > x-w/2 && xPt < x+w/2 && yPt > y-h/2 && yPt < y+h/2) {
 			// Clicked
 			toggleEnabled();

--- a/src/com/modsim/modules/parts/VisiblePart.java
+++ b/src/com/modsim/modules/parts/VisiblePart.java
@@ -20,7 +20,7 @@ public abstract class VisiblePart {
 	public BaseModule owner;
 
 	// Interaction
-	public boolean lbDown(int x, int y) {return false;}
+	public boolean lbDown(int x, int y, boolean isShiftDown) {return false;}
 	public boolean lbUp(int x, int y) {return false;}
 
 	// Display

--- a/src/com/modsim/tools/BaseTool.java
+++ b/src/com/modsim/tools/BaseTool.java
@@ -18,7 +18,7 @@ public abstract class BaseTool {
 	public BaseTool rbDown(int x, int y)  	{return this;}
 	public BaseTool rbUp(int x, int y)  	{return this;}
 
-	public BaseTool lbDown(int x, int y) 	{return this;}
+	public BaseTool lbDown(int x, int y, boolean isShiftDown) 	{return this;}
 	public BaseTool lbUp(int x, int y) 		{return this;}
 	public BaseTool mouseMove(int x, int y) {return this;}
 	public BaseTool mouseDrag(int x, int y) {return this;}

--- a/src/com/modsim/tools/EditLinkTool.java
+++ b/src/com/modsim/tools/EditLinkTool.java
@@ -6,7 +6,7 @@ import com.modsim.modules.Link;
 import com.modsim.operations.CreateOperation;
 import com.modsim.operations.MoveOperation;
 import com.modsim.res.Colors;
-import com.modsim.util.BezierPath.PointInfo;
+import com.modsim.util.Path.PointInfo;
 import com.modsim.util.CtrlPt;
 import com.modsim.util.Vec2;
 
@@ -77,7 +77,7 @@ public class EditLinkTool extends BaseTool {
     }
 
     @Override
-    public BaseTool lbDown(int x, int y) {
+    public BaseTool lbDown(int x, int y, boolean isShiftDown) {
         // Try picking nearest control point
         Vec2 worldPoint = ViewUtil.screenToWorld(new Vec2(x, y));
         CtrlPt pickCtrl = link.path.closestCtrlPt(worldPoint);

--- a/src/com/modsim/tools/MakeLinkTool.java
+++ b/src/com/modsim/tools/MakeLinkTool.java
@@ -23,15 +23,15 @@ public class MakeLinkTool extends BaseTool {
 
 	public Vec2 start = new Vec2();
 	public Vec2 current = new Vec2();
-	public BezierPath curve;
+	public Path curve;
 
 	public boolean working = false;
 
 	@Override
-	public BaseTool lbDown(int x, int y) {
+	public BaseTool lbDown(int x, int y, boolean isShiftDown) {
 		// Get the clicked port, start linking from here
 		if (!working) {
-			if (!startLink(x, y)) {
+			if (!startLink(x, y, isShiftDown)) {
 				return null;
 			}
 		}
@@ -93,14 +93,18 @@ public class MakeLinkTool extends BaseTool {
 	 * @param y Y position to check
 	 * @return True if successful
 	 */
-	public boolean startLink(int x, int y) {
+	public boolean startLink(int x, int y, boolean isShiftDown) {
 		source = ViewUtil.screenSpace_portAt(x, y);
 		if (source != null) {
             Main.selection.clear();
 
             working = true;
 			start = new Vec2(x, y);
-			curve = new BezierPath();
+            if (isShiftDown) {
+	             curve = new BezierPath();
+            } else {
+                curve = new StraightPath();
+            }
 
 			curve.setEnd(source.getDisplayPosW());
 			curve.setStart(source);

--- a/src/com/modsim/tools/PlaceTool.java
+++ b/src/com/modsim/tools/PlaceTool.java
@@ -72,7 +72,7 @@ public class PlaceTool extends BaseTool {
     }
 
     @Override
-    public BaseTool lbDown(int x, int y) {
+    public BaseTool lbDown(int x, int y, boolean isShiftDown) {
         // Make sure the positions are up to date
         mouseMove(x, y);
 

--- a/src/com/modsim/tools/SelectTool.java
+++ b/src/com/modsim/tools/SelectTool.java
@@ -61,7 +61,7 @@ public class SelectTool extends BaseTool {
 
     // This just fixes the weird delayed-start drag bug
     @Override
-    public BaseTool lbDown(int x, int y) {
+    public BaseTool lbDown(int x, int y, boolean isShiftDown) {
         synchronized (this) {
             // Don't actually set dragging=true till we get a mouseDrag() event
             screenDragStart.set(x, y);

--- a/src/com/modsim/util/CtrlPt.java
+++ b/src/com/modsim/util/CtrlPt.java
@@ -10,7 +10,7 @@ import com.modsim.operations.DeleteOperation;
 
 public class CtrlPt extends PickableEntity {
 
-    public BezierPath parent = null;
+    public Path parent = null;
 
     /**
      * Create a control point at the specified position

--- a/src/com/modsim/util/ModuleClipboard.java
+++ b/src/com/modsim/util/ModuleClipboard.java
@@ -147,7 +147,7 @@ public class ModuleClipboard {
 
                     newPort.link = null;
                     targetPort.link = null;
-                    Link newLink = Link.createLink(newPort, targetPort, new BezierPath(oldPort.link.path));
+                    Link newLink = Link.createLink(newPort, targetPort, oldPort.link.path.duplicate());
 
                     // Store the new link
                     if (newLink != null) {

--- a/src/com/modsim/util/Path.java
+++ b/src/com/modsim/util/Path.java
@@ -1,0 +1,53 @@
+package com.modsim.util;
+
+import java.awt.Graphics2D;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.modsim.modules.parts.Port;
+import com.modsim.Main;
+
+public abstract class Path {
+
+    public class PointInfo {
+        public Vec2 pt;
+        public double dist;
+        public double t;
+        public int curveIndex;
+
+        public String toString() {
+            return pt.toString() + ", " + dist + ", " + t + ", " + curveIndex;
+        }
+    }
+
+	protected ArrayList<CtrlPt> ctrlPts = new ArrayList<>();
+
+    public abstract PointInfo approxClosestPoint(Vec2 searchPt, int iterations);
+    public abstract CtrlPt closestCtrlPt(Vec2 searchPt);
+
+    public abstract Path duplicate();
+
+    public abstract void updateContours();
+
+    public abstract void calcCurves();
+
+    public abstract void draw(Graphics2D g);
+
+    public abstract List<CtrlPt> getCtrlPts();
+
+    public abstract void setStart(Vec2 end);
+	public abstract void setStart(Vec2 end, Vec2 c);
+	public abstract void setStart(Port p);
+    public abstract void setEnd(Vec2 end);
+	public abstract void setEnd(Vec2 end, Vec2 c);
+	public abstract void setEnd(Port p);
+
+    public abstract void reverse();
+
+    public abstract void addPt(CtrlPt pt);
+    public abstract void addPt(int index, CtrlPt pt);
+    public abstract boolean removePt();
+    public abstract void removePt(CtrlPt ctrlPt);
+
+    public abstract String XMLTagName();
+}

--- a/src/com/modsim/util/StraightLine.java
+++ b/src/com/modsim/util/StraightLine.java
@@ -1,0 +1,69 @@
+package com.modsim.util;
+
+import java.awt.Graphics2D;
+import java.awt.geom.Line2D;
+
+public class StraightLine {
+
+	public Vec2 p1 = new Vec2();
+	public Vec2 p2 = new Vec2();
+
+	public Line2D line;
+
+	/**
+	 * Create a new bezier line
+	 */
+	public StraightLine(Vec2 pt1, Vec2 pt2) {
+		p1.set(pt1);
+		p2.set(pt2);
+
+		line = new Line2D.Double(p1.x, p1.y, p2.x, p2.y);
+	}
+
+	public StraightLine() {
+		line = new Line2D.Double(p1.x, p1.y, p2.x, p2.y);
+	}
+
+	/**
+	 * Update the display line
+	 */
+	public void update() {
+		line = new Line2D.Double(p1.x, p1.y, p2.x, p2.y);
+	}
+
+	/**
+	 * Calculate a point on the line
+	 * @param t Point on line to calculate
+	 * @return Cartesian coordinates of point
+	 */
+	public Vec2 calcPoint(double t) {
+        Vec2 a = new Vec2();
+        t = t * (p1.dist(p2));
+
+        if (p2.x - p1.x == 0) {
+            a.set(p1.x, p1.y + (p2.y - p1.y < 0 ? -t : t));
+        }
+        else {
+            double m = (p2.y - p1.y) / (p2.x - p1.x);
+            a.set(p1.x + (p2.x - p1.x < 0 ? -t : t), p1.y + (m * (p2.x - p1.x < 0 ? -t : t)));
+        }
+        
+		return a;
+	}
+
+	/**
+	 * Draw the line using java's straight line
+	 */
+	public void draw(Graphics2D g) {
+		g.draw(line);
+	}
+
+	/**
+	 * Return distance between start and end point
+	 */
+	public double len() {
+		Vec2 d = new Vec2(p1);
+		d.sub(p2);
+		return d.len();
+	}
+}

--- a/src/com/modsim/util/StraightPath.java
+++ b/src/com/modsim/util/StraightPath.java
@@ -8,31 +8,30 @@ import com.modsim.modules.parts.Port;
 import com.modsim.Main;
 
 /**
- * Manages a path consisting of connected bezier curves
+ * Manages a path consisting of connected bezier lines
  * @author aw12700
  *
  */
-public class BezierPath extends Path {
+public class StraightPath extends Path {
 
-	public List<BezierCurve> curves = new ArrayList<>();
-	protected ArrayList<CtrlPt> ctrlPts = new ArrayList<>();
+	public List<StraightLine> lines = new ArrayList<>();
 
 	public PointInfo approxClosestPoint(Vec2 searchPt, int iterations) {
 		Vec2 bestPoint = new Vec2();
 		double bestDist = Double.POSITIVE_INFINITY;
         double bestT = 0;
-        int bestCurveIndex = -1;
+        int bestcurveIndex = -1;
 
-		for (int cInd = 0; cInd < curves.size(); cInd++) {
-            BezierCurve curve = curves.get(cInd);
+		for (int cInd = 0; cInd < lines.size(); cInd++) {
+            StraightLine line = lines.get(cInd);
 			double topT = 1.0;
 			double bottomT = 0.0;
 
 			for (int i = 0; i < iterations; i++) {
 				double t1 = bottomT + (topT - bottomT) / 4;
 				double t2 = topT - (topT - bottomT) / 4;
-				Vec2 p1 = curve.calcPoint(t1);
-				Vec2 p2 = curve.calcPoint(t2);
+				Vec2 p1 = line.calcPoint(t1);
+				Vec2 p2 = line.calcPoint(t2);
 
 				if (p1.dist(searchPt) < p2.dist(searchPt)) {
 					topT = (topT + bottomT) / 2;
@@ -42,12 +41,12 @@ public class BezierPath extends Path {
 				}
 			}
 
-			Vec2 curvePoint = curve.calcPoint((topT + bottomT) / 2);
-			double curveDist = curvePoint.dist(searchPt);
-			if (curveDist < bestDist) {
-				bestDist = curveDist;
-				bestPoint = curvePoint;
-                bestCurveIndex = cInd;
+			Vec2 linePoint = line.calcPoint((topT + bottomT) / 2);
+			double lineDist = linePoint.dist(searchPt);
+			if (lineDist < bestDist) {
+				bestDist = lineDist;
+				bestPoint = linePoint;
+                bestcurveIndex = cInd;
                 bestT = (topT + bottomT) / 2;
 			}
 		}
@@ -55,7 +54,7 @@ public class BezierPath extends Path {
         PointInfo pInfo = new PointInfo();
         pInfo.pt = bestPoint;
         pInfo.dist = bestDist;
-        pInfo.curveIndex = bestCurveIndex;
+        pInfo.curveIndex = bestcurveIndex;
         pInfo.t = bestT;
 		return pInfo;
 	}
@@ -81,142 +80,107 @@ public class BezierPath extends Path {
 	 * @param end The end-point
 	 * @param c2off Offset for the second control point (from end)
 	 */
-	public BezierPath(Vec2 start, Vec2 c1off, Vec2 end, Vec2 c2off) {
-		Vec2 c1 = new Vec2(start);
-		c1.add(c1off);
-
-		Vec2 c2 = new Vec2(end);
-		c2.add(c2off);
-
-		curves.add(new BezierCurve(start, end, c1, c2));
+	public StraightPath(Vec2 start, Vec2 end) {
+		lines.add(new StraightLine(start, end));
 	}
 
 	/**
 	 * Creates an "isEmpty" path
 	 */
-	public BezierPath() {
-		curves.add(new BezierCurve(new Vec2(), new Vec2(), new Vec2(), new Vec2()));
+	public StraightPath() {
+		lines.add(new StraightLine(new Vec2(), new Vec2()));
 	}
 
 	/**
 	 * Creates a duplicate path
-	 * @param curve
+	 * @param line
 	 */
-	public BezierPath(BezierPath curve) {
+	public StraightPath(StraightPath line) {
 	    this();
 
-        for (CtrlPt c : curve.ctrlPts) {
+        for (CtrlPt c : line.ctrlPts) {
             addPt((CtrlPt) c.createNew());
         }
         calcCurves();
     }
 
     public Path duplicate() {
-        return new BezierPath(this);
+        return new StraightPath(this);
     }
 
     /**
 	 * Moves the startpoint
 	 */
 	public void setStart(Vec2 end) {
-		BezierCurve first = curves.get(0);
+		StraightLine first = lines.get(0);
 		first.p1 = new Vec2(end);
-		first.c1 = new Vec2(end);
 		first.update();
 	}
 	public void setStart(Vec2 end, Vec2 c) {
-		BezierCurve first = curves.get(0);
-		first.p1 = new Vec2(end);
-		first.c1 = new Vec2(c);
-		first.update();
-	}
+        setStart(end);
+    }
 	public void setStart(Port p) {
-		Vec2 c1;
-
-		if (p.type == Port.CTRL || p.type == Port.CLOCK)
-			c1 = new Vec2(p.side * Main.sim.grid * 2, 0);
-		else
-			c1 = new Vec2(0, p.side * Main.sim.grid * 2);
-
-		c1.add(p.getDisplayPos());
-		c1 = p.owner.objToWorld(c1);
-
-		setStart(p.getDisplayPosW(), c1);
+		setStart(p.getDisplayPosW());
 	}
 
 	/**
 	 * Moves the endpoint
 	 */
 	public void setEnd(Vec2 end) {
-		setEnd(end, end);
-	}
-	public void setEnd(Vec2 end, Vec2 c) {
-		BezierCurve last = curves.get(curves.size() - 1);
+		StraightLine last = lines.get(lines.size() - 1);
 		last.p2 = new Vec2(end);
-		last.c2 = new Vec2(c);
-
 		updateContours();
 	}
+	public void setEnd(Vec2 end, Vec2 c) {
+        setEnd(end);
+    }
 	public void setEnd(Port p) {
-		Vec2 c1;
-
-		if (p.type == Port.CTRL || p.type == Port.CLOCK)
-			c1 = new Vec2(p.side*Main.sim.grid*2, 0);
-		else
-			c1 = new Vec2(0, p.side*Main.sim.grid*2);
-
-		c1.add(p.getDisplayPos());
-		c1 = p.owner.objToWorld(c1);
-
-		setEnd(p.getDisplayPosW(), c1);
+		setEnd(p.getDisplayPosW());
 	}
 
 	/**
 	 * Updates the path list
 	 */
 	public void calcCurves() {
-		Vec2 start = curves.get(0).p1;
-		Vec2 startC = curves.get(0).c1;
+		Vec2 start = lines.get(0).p1;
+		Vec2 end = lines.get(lines.size() - 1).p2;
 
-		Vec2 end = curves.get(curves.size() - 1).p2;
-		Vec2 endC = curves.get(curves.size() -1).c2;
-
-		curves.clear();
+		lines.clear();
 
 		// First path - start pt and first ctrl pt
-		curves.add(new BezierCurve());
-		setStart(start, startC);
+		lines.add(new StraightLine());
+		setStart(start);
 
 		// Iterate the control points
 		for (int i = 0; i < ctrlPts.size(); i++) {
 			Vec2 pt = ctrlPts.get(i).pos;
 
 			// Update existing path
-			curves.get(i).p2 = pt;
+			lines.get(i).p2 = pt;
 
 			// Add next path
-			BezierCurve c = new BezierCurve();
+			StraightLine c = new StraightLine();
 			c.p1 = pt;
-			curves.add(c);
+			lines.add(c);
 		}
 
 		// Set end
-		setEnd(end, endC);
+		setEnd(end);
 
 		// Update the contours
 		updateContours();
 	}
 
 	/**
-	 * Updates the (intermediate) curves to new control points
+	 * Updates the (intermediate) lines to new control points
 	 */
 	public void updateContours() {
-		for (int i = 0; i < curves.size(); i++) {
-			BezierCurve last2 = null;
+		for (int i = 0; i < lines.size(); i++) {
+			StraightLine last2 = null;
 			if (i - 1 >= 0) {
-				last2 = curves.get(i - 1);
+				last2 = lines.get(i - 1);
 			}
-			BezierCurve last = curves.get(i);
+			StraightLine last = lines.get(i);
 
 			Vec2 compPt;
 			if (last2 != null) {
@@ -224,25 +188,6 @@ public class BezierPath extends Path {
 			}
 			else {
 				compPt = last.p1;
-			}
-
-			// Delta
-			Vec2 d = new Vec2(last.p2);
-			d.sub(compPt);
-
-			if (last2 != null) {
-				// last.c1 offset = d
-				Vec2 c = new Vec2(d);
-				c.setLen(last.len() / 2);
-				c.add(last.p1);
-				last.c1 = c;
-
-				// last2.c2 offset = -d
-				c = new Vec2(d);
-				c.setLen(last2.len() / 2);
-				c.neg();
-				c.add(last2.p2);
-				last2.c2 = c;
 			}
 
 			last.update();
@@ -330,7 +275,7 @@ public class BezierPath extends Path {
 	 */
 	public void draw(Graphics2D g) {
 		// Draw lines
-		for (BezierCurve c : curves) {
+		for (StraightLine c : lines) {
 			c.draw(g);
 		}
 
@@ -342,6 +287,6 @@ public class BezierPath extends Path {
 	}
 
     public String XMLTagName() {
-        return "BezierPath";
+        return "StraightPath";
     }
 }

--- a/src/com/modsim/util/XMLReader.java
+++ b/src/com/modsim/util/XMLReader.java
@@ -145,6 +145,9 @@ public class XMLReader {
             NodeList links = doc.getElementsByTagName("link");
             int badLinks = 0;
 
+            String BezierPathTagName = new BezierPath().XMLTagName();
+            String StraightPathTagName = new StraightPath().XMLTagName();
+
             for (int i = 0; i < links.getLength(); i++) {
                 Node n = links.item(i);
 
@@ -153,6 +156,7 @@ public class XMLReader {
 
                     int srcID = Integer.parseInt(link.getAttribute("src"));
                     int targID = Integer.parseInt(link.getAttribute("targ"));
+                    String tagName = link.getAttribute("type");
 
                     if (srcID == targID) {
                         System.err.println("Warning: Link's source and target are the same ("+srcID+"). Skipping link");
@@ -172,7 +176,16 @@ public class XMLReader {
                     }
 
                     // Generate the bezier path
-                    BezierPath curve = new BezierPath();
+                    Path curve;
+                    if (tagName.equals(BezierPathTagName)) {
+                        curve = new BezierPath();
+                    }
+                    else if (tagName.equals(StraightPathTagName)) {
+                        curve = new StraightPath();
+                    }
+                    else {
+                        curve = new BezierPath();
+                    }
 
                     NodeList points = link.getElementsByTagName("ctrlPt");
                     for (int j = 0; j < points.getLength(); j++) {

--- a/src/com/modsim/util/XMLWriter.java
+++ b/src/com/modsim/util/XMLWriter.java
@@ -157,6 +157,7 @@ public class XMLWriter {
                     Element lElem = doc.createElement("link");
                     lElem.setAttribute("src", "" + l.src.ID);
                     lElem.setAttribute("targ", "" + l.targ.ID);
+                    lElem.setAttribute("type", l.path.XMLTagName());
 
                     // Curve points
                     for (CtrlPt c : l.path.ctrlPts) {


### PR DESCRIPTION
Most of our students end up trying to create straight lines using the curved ones by placing two points on top of each other. This is error prone, tedious, difficult to edit, slow and creates glitches in the visualisation of lines where curves go round sharp corners.

To address these issues, I have backwards-compatibly added straight lines. Old versions of ModuleSim can open the new files and vice-versa. 

Straight lines are now the default when creating lines. Use Shift+Click to create curved lines.