### PR TITLE
small patch to allow compiling+running on newer Java versions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 mkdir ./out
 find -name "*.java" > sources.txt
-javac -d ./out @sources.txt
+BUILD_COMMAND="javac -d ./out @sources.txt"
+${BUILD_COMMAND} --add-exports=java.desktop/sun.awt=ALL-UNNAMED || \
+  echo "Command failed, retrying assuming older Java build" && ${BUILD_COMMAND}
 cd ./out
 find ../src -name "*.png" -exec cp '{}' ./com/modsim/res/ \;
 jar cfm ../ModuleSim-Test.jar ../src/META-INF/MANIFEST.MF ./

--- a/src/META-INF/MANIFEST.MF
+++ b/src/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: com.modsim.Main
-
+Add-Exports: java.desktop/sun.awt


### PR DESCRIPTION
Trying to run ModuleSim on more recent versions of java causes an error due to `module java.desktop does not export sun.awt to unnamed module`. This patch to the MANIFEST.MF fixes this by ensuring that `sun.awt` is exported. When compiling on newer versions of Java, the `--add-exports` command also needs to be passed to javac, so this has been added to the build script, but falls back to running without the flag for the older versions of javac that do not support this flag.