### PR TITLE
New fixes for compiling on newer Java versions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-mkdir ./out
+[ -d ./out ] || mkdir ./out
 find -name "*.java" > sources.txt
 javac -d ./out @sources.txt
 cd ./out

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,6 @@
 mkdir ./out
 find -name "*.java" > sources.txt
-BUILD_COMMAND="javac -d ./out @sources.txt"
-${BUILD_COMMAND} --add-exports=java.desktop/sun.awt=ALL-UNNAMED || \
-  echo "Command failed, retrying assuming older Java build" && ${BUILD_COMMAND}
+javac -d ./out @sources.txt
 cd ./out
 find ../src -name "*.png" -exec cp '{}' ./com/modsim/res/ \;
 jar cfm ../ModuleSim-Test.jar ../src/META-INF/MANIFEST.MF ./

--- a/src/META-INF/MANIFEST.MF
+++ b/src/META-INF/MANIFEST.MF
@@ -1,3 +1,2 @@
 Manifest-Version: 1.0
 Main-Class: com.modsim.Main
-Add-Exports: java.desktop/sun.awt

--- a/src/com/modsim/simulator/Sim.java
+++ b/src/com/modsim/simulator/Sim.java
@@ -12,7 +12,6 @@ import com.modsim.Main;
 import com.modsim.modules.*;
 import static com.modsim.modules.BaseModule.AvailableModules;
 import com.modsim.modules.parts.Port;
-import sun.awt.Mutex;
 
 import com.modsim.util.BinData;
 import com.modsim.util.CtrlPt;
@@ -20,7 +19,7 @@ import com.modsim.util.CtrlPt;
 public class Sim implements Runnable {
 
     private Thread thread;
-    public final Mutex lock = new Mutex();
+    public final Object lock = new Object();
 
     private int lastLinkInd = 0;
 

--- a/src/com/modsim/util/ModuleClipboard.java
+++ b/src/com/modsim/util/ModuleClipboard.java
@@ -185,6 +185,7 @@ public final class ModuleClipboard implements ClipboardOwner {
         
         if (hasTransferableFiles) {
             try {
+                @SuppressWarnings("unchecked")
                 List<File> files = (List<File>) contents.getTransferData(DataFlavor.javaFileListFlavor);
                 if (files.size() == 1) {
                     File file = files.get(0);


### PR DESCRIPTION
About a year ago I created a PR that introduced a small shim into the manifest and build script for fixing this project on newer versions of Java. Unfortunately this shim doesn't seem to properly work anymore, rendering it mostly ineffective.

This PR hopes to address these issues once again with a proper solution instead of a hacky workaround. The issue currently is with `sun.awt.Mutex` not being exported into the Java Runtime in newer versions.

Looking at the source code reveals that the only use of a `sun.awt.Mutex` is for mutual exclusion in some `synchronized` blocks. However Java allows you to synchronise over any type of object, so we can just change the type to `Object` to remove our dependency without changing any behaviour.

I have a release on my own fork tagged as `0.4.1`, which was compiled with Java 8. I have additionally tested it against Java 17 and 21 and everything appears to work correctly.